### PR TITLE
Fix grouping with error bars

### DIFF
--- a/R/dumbbellPlot.R
+++ b/R/dumbbellPlot.R
@@ -141,6 +141,12 @@ dumbbellPlot <- function(data, x, y, colour.by = "X variables", palette.selectio
 
     sharing <- .resolve_facet_sharing(facet.scales)
 
+    # Clear per-axis titles when faceting - single titles added as annotations instead
+    if (!is.null(facet.by) && facet.by != "") {
+        xaxis_style$title <- NULL
+        yaxis_style$title <- NULL
+    }
+
     # Main plotting logic
     if (!is.null(facet.by) && facet.by != "") {
         # WITH FACETING
@@ -160,10 +166,10 @@ dumbbellPlot <- function(data, x, y, colour.by = "X variables", palette.selectio
 
         fig <- subplot(
             plots, nrows = 1, shareX = sharing$shareX, shareY = sharing$shareY,
-            titleX = TRUE, titleY = TRUE, margin = subplot.margin
+            titleX = FALSE, titleY = FALSE, margin = subplot.margin
         )
 
-        annotations <- .build_facet_annotations(facet_levels)
+        annotations <- .build_facet_annotations(facet_levels, x.title = x.title, y.title = y.title)
         fig <- fig |> layout(annotations = annotations)
     } else {
         # WITHOUT FACETING

--- a/R/dumbbellPlot_module_ui.R
+++ b/R/dumbbellPlot_module_ui.R
@@ -50,7 +50,7 @@
 #'     Men = c(152, 151, 165)
 #' )
 #' dumbbellPlotInputsUI("dumbbellPlot", data)
-dumbbellPlotInputsUI <- function(id, data, defaults = NULL, title = NULL, columns = 2) {
+dumbbellPlotInputsUI <- function(id, data, defaults = list("subplot.margin" = 0.05), title = NULL, columns = 2) {
     ns <- NS(id)
 
     # Get variables of data.

--- a/R/linePlot.R
+++ b/R/linePlot.R
@@ -3,14 +3,22 @@
 #' Generates a customizable interactive line plot using plotly, supporting grouping, faceting, axis adjustments, and color palettes.
 #'
 #' @param data A data.frame or tibble containing the data to plot.
-#' @param x Character vector of column name(s) for the x-axis. Multiple columns create separate traces.
-#' @param y Character vector of column name(s) for the y-axis. Multiple columns create separate traces.
-#' @param plot.mode Character, plotly mode for plot type. Options: "lines", "markers", "lines+markers". Default: "lines".
-#' @param line.type Character, line style. Options: "solid", "dot", "dash", "longdash", "dashdot", "longdashdot". Default: "solid".
-#' @param colour.group.by Character or formula, column name(s) to group lines by color. Can be a formula like \code{~ column_name}.
-#' @param palette.selection Character vector of hex colors or palette name for line colors. Used to assign colors to groups or traces.
+#' @param x Character vector of column name(s) for the x-axis.
+#'   Multiple columns create separate traces.
+#' @param y Character vector of column name(s) for the y-axis.
+#'   Multiple columns create separate traces.
+#' @param palette.selection Character vector of hex colors for line colors.
+#'   Used to assign colors to groups or traces.
+#' @param plot.mode Character, plotly mode for plot type.
+#'   Options: "lines", "markers", "lines+markers". Default: "lines".
+#' @param line.type Character, line style.
+#'   Options: "solid", "dot", "dash", "longdash", "dashdot", "longdashdot". Default: "solid".
+#' @param colour.group.by Character or formula, column name(s) to group lines by color.
+#'   Can be a formula like \code{~ column_name}. Ignored if multiple `x` or `y` columns are provided.
+#'   Default: `NULL`.
 #' @param show.legend Logical, whether to display the legend. Default: TRUE.
-#' @param facet.by Optional character, column name to facet plots by. Creates subplots for each unique value. Default: NULL.
+#' @param facet.by Optional character, column name to facet plots by.
+#'   Creates subplots for each unique value. Default: NULL.
 #' @param facet.scales Character, controls axis scaling across facets. Options: "fixed" (same for all), "free" (independent),
 #'   "free_x" (independent x-axis), "free_y" (independent y-axis). Default: "fixed".
 #' @param subplot.margin Numeric, spacing between facet panels as a fraction of the plot area. Default: 0.05.
@@ -68,7 +76,10 @@
 #'     palette.selection = palette,
 #'     show.legend = TRUE
 #' )
-linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.selection, show.legend, facet.by = NULL,
+linePlot <- function(data, x, y, palette.selection, 
+                     plot.mode = "lines", line.type = "solid", 
+                     colour.group.by = NULL,
+                     show.legend = TRUE, facet.by = NULL,
                      facet.scales = "fixed",
                      subplot.margin = 0.05,
                      axis.showline = TRUE, axis.mirror = TRUE, axis.linecolor = "black", axis.linewidth = 0.5, axis.tickfont.size = 12,
@@ -89,7 +100,7 @@ linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.
 
     cat.choices <- c("", names(data)[vapply(data, function(x) !is.numeric(x), logical(1))])
 
-    if (!is.null(x.adjustment) && x.adjustment != "") {
+    if (!is.null(x.adjustment) && nzchar(x.adjustment)) {
         data <- .adjust_column_values(df = data, x.col = x, x.adj.fun = x.adjustment)
         x.new <- x
         for (i in seq_along(x)) {
@@ -101,7 +112,7 @@ linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.
         x <- x.new
     }
 
-    if (!is.null(y.adjustment) && y.adjustment != "") {
+    if (!is.null(y.adjustment) && nzchar(y.adjustment)) {
         data <- .adjust_column_values(df = data, y.col = y, y.adj.fun = y.adjustment)
         y.new <- y
         for (i in seq_along(y)) {
@@ -112,25 +123,27 @@ linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.
         }
         y <- y.new
     }
-    if (!is.null(color.adjustment) && color.adjustment != "") {
-        data <- .adjust_column_values(df = data, color.col = colour.group.by, color.adj.fun = color.adjustment)
-        colour.group.by.new <- colour.group.by
-        for (i in seq_along(colour.group.by)) {
-            adj_name <- paste(colour.group.by[i], "adj", sep = ".")
-            if (adj_name %in% names(data)) {
-                colour.group.by.new[i] <- adj_name
-            }
-        }
-        colour.group.by <- colour.group.by.new
-    }
 
+    if (!is.null(color.adjustment) && nzchar(color.adjustment) && !is.null(colour.group.by) && nzchar(colour.group.by)) {
+        data <- .adjust_column_values(df = data, color.col = colour.group.by, color.adj.fun = color.adjustment)
+        adj_name <- paste(colour.group.by, "adj", sep = ".")
+
+        if (adj_name %in% names(data)) {
+            colour.group.by <- adj_name
+        }
+    }
 
     if (length(x) == 1 && x %in% cat.choices) {
         # Compute per-group mean and SD for error bars
         group_vars <- x
         if (!is.null(facet.by) && nzchar(facet.by)) {
-            group_vars <- c(facet.by, x)
+            group_vars <- c(facet.by, group_vars)
         }
+
+        if (!is.null(colour.group.by) && nzchar(colour.group.by)) {
+            group_vars <- c(colour.group.by, group_vars)
+        }
+
         ex <- data |>
             dplyr::group_by(dplyr::across(dplyr::all_of(group_vars))) |>
             dplyr::summarise(
@@ -168,8 +181,6 @@ linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.
         yaxis_style$title <- NULL
     }
 
-
-
     order.cols <- order.by
     if (is.null(order.cols)) {
         order.cols <- x
@@ -181,6 +192,12 @@ linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.
     }
 
     multi_axis <- xor(length(x) > 1, length(y) > 1)
+
+    if (!is.null(colour.group.by) && nzchar(colour.group.by)) {
+        color <- reformulate(colour.group.by)
+    } else {
+        color <- NULL
+    }
 
     if (!is.null(facet.by) && facet.by != "" && !multi_axis) {
         # Split data by facet variable
@@ -194,7 +211,7 @@ linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.
                 y = reformulate(y),
                 type = "scatter",
                 mode = plot.mode,
-                color = colour.group.by,
+                color = color,
                 colors = palette.selection,
                 showlegend = show.legend
             )
@@ -254,7 +271,7 @@ linePlot <- function(data, x, y, plot.mode, line.type, colour.group.by, palette.
             y = reformulate(y),
             type = "scatter",
             mode = plot.mode,
-            color = colour.group.by,
+            color = color,
             colors = palette.selection,
             showlegend = show.legend
         )

--- a/R/linePlot_module_server.R
+++ b/R/linePlot_module_server.R
@@ -181,7 +181,7 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
                 default_palette_values
             )
 
-            palette_selection <- unname(palette_values)
+            palette_selection <- palette_values
             if (is.null(palette_selection) || length(palette_selection) == 0) {
                 palette_selection <- default_palette_values
             }

--- a/R/linePlot_module_server.R
+++ b/R/linePlot_module_server.R
@@ -261,7 +261,7 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
                 colour.group.by = group.by,
                 palette.selection = palette_selection,
                 show.legend = show_legend,
-                facet.by = isolate_fn(input$facet.by),
+                facet.by = facet.by,
                 facet.scales = isolate_fn(input$facet.scales),
                 subplot.margin = isolate_fn(input$subplot.margin),
                 order.by = order_by,

--- a/R/linePlot_module_server.R
+++ b/R/linePlot_module_server.R
@@ -180,15 +180,16 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
                 isolate_fn(input$palette.colours),
                 default_palette_values
             )
+
             palette_selection <- unname(palette_values)
             if (is.null(palette_selection) || length(palette_selection) == 0) {
                 palette_selection <- default_palette_values
             }
 
-            group.by <- palette_selection[1]
+            group.by <- NULL
             show_legend <- FALSE
             if (isolate_fn(input$group.by) != "" && length(x_input) == 1 && length(y_input) == 1) {
-                group.by <- reformulate(isolate_fn(input$group.by))
+                group.by <- isolate_fn(input$group.by)
                 show_legend <- TRUE
             } else if (length(x_input) > 1 || length(y_input) > 1) {
                 show_legend <- TRUE
@@ -201,7 +202,7 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
             axis_min_x <- NULL
             axis_max_x <- NULL
 
-            # Choosing which axis to order by:
+            # Order by selected axis
             order_by <- x_input
             if (isolate_fn(input$order.by)) {
                 order_by <- y_input
@@ -215,7 +216,7 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
                 d <- d[do.call(order, d[, order_by, drop = FALSE]), ]
             }
 
-            # Axis title:
+
             x_title <- x_input[1]
             if (length(x_input) > 1) {
                 x_title <- "Value"
@@ -245,14 +246,16 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
                 updateSelectInput(session, "y.adjustment", selected = "")
                 y.adjustment <- NULL
             }
+
             facet.by <- NULL
             if (!isolate_fn(input$facet.by) == "") {
                 facet.by <- isolate_fn(input$facet.by)
             }
+
             fig <- linePlot(
                 data = d,
-                x = x_input,
-                y = y_input,
+                x = isolate_fn(input$x.value),
+                y = isolate_fn(input$y.value),
                 plot.mode = isolate_fn(input$plot.type),
                 line.type = isolate_fn(input$line.type),
                 colour.group.by = group.by,
@@ -345,7 +348,6 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
             return_empty <- FALSE
             txt <- c()
 
-
             if (x_is_cat && y_is_cat) {
                 return_empty <- TRUE
                 txt <- c(txt, "X and Y categories cannot both be discrete data types")
@@ -362,12 +364,19 @@ linePlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NULL, defau
                 return_empty <- TRUE
                 txt <- c(txt, "You cannot have multiple inputs on x and y axis and group by at the same time")
             }
+
             if (return_empty) {
                 fig <- .empty_plot(text = txt, plotly = TRUE)
             } else {
                 fig <- generate_linePlot() |>
                     layout(
-                        margin = list(t = input$margin.t, b = input$margin.b, l = input$margin.l, r = input$margin.r, autoexpand = TRUE)
+                        margin = list(
+                            t = input$margin.t,
+                            b = input$margin.b,
+                            l = input$margin.l,
+                            r = input$margin.r,
+                            autoexpand = TRUE
+                        )
                     )
             }
 

--- a/R/linePlot_module_ui.R
+++ b/R/linePlot_module_ui.R
@@ -92,7 +92,7 @@
 #' library(VizModules)
 #' data(mtcars)
 #' linePlotInputsUI("linePlot", mtcars)
-linePlotInputsUI <- function(id, data, defaults = NULL, title = NULL, columns = 2) {
+linePlotInputsUI <- function(id, data, defaults = list("subplot.margin" = 0.05), title = NULL, columns = 2) {
     ns <- NS(id)
 
     # Get variables of data.

--- a/R/plotthis_AreaPlot_module_server.R
+++ b/R/plotthis_AreaPlot_module_server.R
@@ -162,12 +162,15 @@ plotthis_AreaPlotServer <- function(id, data, hide.inputs = NULL, hide.tabs = NU
             # Convert NA to NULL for facet.ncol and facet.nrow
             facet.ncol <- .na_to_null(isolate_fn(input$facet.ncol))
             facet.nrow <- .na_to_null(isolate_fn(input$facet.nrow))
+
             palette_values <- resolve_palette(
                 isolate_fn(palette_groups()),
                 isolate_fn(input$palette.colours),
                 default_palette_values
             )
+
             palcolor_arg <- NULL
+
             if (!is.null(palette_values) && length(palette_values) > 0) {
                 palcolor_arg <- as.list(palette_values)
             }

--- a/man/dumbbellPlotInputsUI.Rd
+++ b/man/dumbbellPlotInputsUI.Rd
@@ -4,7 +4,13 @@
 \alias{dumbbellPlotInputsUI}
 \title{Input UI components for the dumbbellPlot module}
 \usage{
-dumbbellPlotInputsUI(id, data, defaults = NULL, title = NULL, columns = 2)
+dumbbellPlotInputsUI(
+  id,
+  data,
+  defaults = list(subplot.margin = 0.05),
+  title = NULL,
+  columns = 2
+)
 }
 \arguments{
 \item{id}{The ID for the Shiny module.}

--- a/man/linePlot.Rd
+++ b/man/linePlot.Rd
@@ -8,11 +8,11 @@ linePlot(
   data,
   x,
   y,
-  plot.mode,
-  line.type,
-  colour.group.by,
   palette.selection,
-  show.legend,
+  plot.mode = "lines",
+  line.type = "solid",
+  colour.group.by = NULL,
+  show.legend = TRUE,
   facet.by = NULL,
   facet.scales = "fixed",
   subplot.margin = 0.05,
@@ -51,21 +51,29 @@ linePlot(
 \arguments{
 \item{data}{A data.frame or tibble containing the data to plot.}
 
-\item{x}{Character vector of column name(s) for the x-axis. Multiple columns create separate traces.}
+\item{x}{Character vector of column name(s) for the x-axis.
+Multiple columns create separate traces.}
 
-\item{y}{Character vector of column name(s) for the y-axis. Multiple columns create separate traces.}
+\item{y}{Character vector of column name(s) for the y-axis.
+Multiple columns create separate traces.}
 
-\item{plot.mode}{Character, plotly mode for plot type. Options: "lines", "markers", "lines+markers". Default: "lines".}
+\item{palette.selection}{Character vector of hex colors for line colors.
+Used to assign colors to groups or traces.}
 
-\item{line.type}{Character, line style. Options: "solid", "dot", "dash", "longdash", "dashdot", "longdashdot". Default: "solid".}
+\item{plot.mode}{Character, plotly mode for plot type.
+Options: "lines", "markers", "lines+markers". Default: "lines".}
 
-\item{colour.group.by}{Character or formula, column name(s) to group lines by color. Can be a formula like \code{~ column_name}.}
+\item{line.type}{Character, line style.
+Options: "solid", "dot", "dash", "longdash", "dashdot", "longdashdot". Default: "solid".}
 
-\item{palette.selection}{Character vector of hex colors or palette name for line colors. Used to assign colors to groups or traces.}
+\item{colour.group.by}{Character or formula, column name(s) to group lines by color.
+Can be a formula like \code{~ column_name}. Ignored if multiple \code{x} or \code{y} columns are provided.
+Default: \code{NULL}.}
 
 \item{show.legend}{Logical, whether to display the legend. Default: TRUE.}
 
-\item{facet.by}{Optional character, column name to facet plots by. Creates subplots for each unique value. Default: NULL.}
+\item{facet.by}{Optional character, column name to facet plots by.
+Creates subplots for each unique value. Default: NULL.}
 
 \item{facet.scales}{Character, controls axis scaling across facets. Options: "fixed" (same for all), "free" (independent),
 "free_x" (independent x-axis), "free_y" (independent y-axis). Default: "fixed".}

--- a/man/linePlotInputsUI.Rd
+++ b/man/linePlotInputsUI.Rd
@@ -4,7 +4,13 @@
 \alias{linePlotInputsUI}
 \title{Input UI components for the linePlot module}
 \usage{
-linePlotInputsUI(id, data, defaults = NULL, title = NULL, columns = 2)
+linePlotInputsUI(
+  id,
+  data,
+  defaults = list(subplot.margin = 0.05),
+  title = NULL,
+  columns = 2
+)
 }
 \arguments{
 \item{id}{The ID for the Shiny module.}


### PR DESCRIPTION
Meant to fix #247.

Currently, it splits the groups, but color mapping is off due to multiColorPicker and `colour.group.by` not being resolved appropriately:
<img width="1885" height="648" alt="image" src="https://github.com/user-attachments/assets/927f4932-0d30-4b6f-a9f0-3421951dab77" />

Faceting is also torqued:
<img width="1843" height="594" alt="image" src="https://github.com/user-attachments/assets/eef65664-1df0-4116-9a6f-6a9a48023714" />

